### PR TITLE
Removes local paths and references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ armgcc/release/
 
 # Ignore locally-generated files
 armgcc/mcux_include.json
+.vscode/launch.json
+.vscode/mcuxpresso-tools.json

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ __repo__/
 # Ignore build output directories
 armgcc/debug/
 armgcc/release/
+
+# Ignore locally-generated files
+armgcc/mcux_include.json

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,7 @@
     
       "executable": "",
       "stopAtSymbol": "main",
-      "probeSerialNumber": "ACZIGBXK4EDLT",
+      "probeSerialNumber": "",
       "isAttach": false,
       "probeType": "",
       "skipBuildBeforeDebug": false,

--- a/.vscode/mcuxpresso-tools.json
+++ b/.vscode/mcuxpresso-tools.json
@@ -1,13 +1,13 @@
 {
   "version": "25.3",
-  "toolchainPath": "C:/Users/zac/.mcuxpressotools/arm-gnu-toolchain-13.2.Rel1-mingw-w64-i686-arm-none-eabi",
+  "toolchainPath": "",
   "linkedProjects": [],
   "trustZoneType": "none",
   "multicoreType": "none",
   "projectType": "sdk-freestanding",
   "sdk": {
     "version": "25.03.00",
-    "path": "c:\\Users\\zac\\workspace\\MCUXpresso\\SDKs\\FRDM-MCXN947",
+    "path": "",
     "boardId": "frdmmcxn947",
     "deviceId": "MCXN947",
     "coreId": "cm33_core0_MCXN947"

--- a/readme.md
+++ b/readme.md
@@ -3,19 +3,18 @@
 Prints "Hello, world." to UART debug console, then enters forever-loop that echos any characters sent to that UART.
 
 ## How to Build
-First, ensure that the paths provided under the "environment" entry in armgcc/mcux_include.json are valid (i.e., ARMGCC_DIR provides a valid path to the specified toolchain, SdkRootDirPath provides a valid path to the specified SDK, etc.).
+This project is developed around MCUXpresso for VS Code.  
 
-### Method 1
-1. Import the project using MCUXpresso for VS Code.
-2. In the MCUXpresso for VS Code panel, right-click the project and select Build Project.
-
-### Method 2
-1. In a Powershell terminal, navigate to the armgcc/ subdirectory.
-2. Enter `./build_all.bat` into the terminal.
-
-### Method 3
-1. In a WSL or Linux terminal, navigate to the armgcc/ subdirectory.
-2. Enter `./build_all.sh` into the terminal.
+1. Import the project using MCUXpresso for VS Code:
+   - Select Import Project in the MCUXpresso VS Code extension panel. This will open an Import Project tab.
+   - Select the project folder (i.e., the folder containing this readme.md file) as the import path.
+   - Confirm the detection of the MCUXpresso SDK project named HelloBaremetal.
+   - Populate the Repository selection box with a path to a local FRDM-MCXN947 SDK repository.
+     - SDKs can be imported by selecting Import Repository in the MCUXpresso VS Code panel.
+   - Populate the Toolchain selection box with the path to MCUXpresso's ARMGCC toolchain.
+     - Likely located at `C:/Users/your_username/.mcuxpressotools/arm-gnu-toolchain-13.2.Rel1-mingw-w64-i686-arm-none-eabi`.
+   - Select Import, then select cm33_core0 when prompted for a core for which to build.
+2. In the MCUXpresso for VS Code panel, right-click the imported HelloBaremetal project and select Build Project.
 
 ## How to Run
 1.  Connect a type-c USB cable between the PC host and the MCU-Link USB port (J17) on the board


### PR DESCRIPTION
- Removes SDK and toolchain paths from .vscode/mcuxpresso-tools.json.
  - These paths are automatically filled when the project is imported into MCUXpresso for VS Code.
- Removes debug probe serial number from .vscode/launch.json.
  - This is also automatically filled by MCUXpresso for VS Code upon successful debug probe connection.
- Updates readme.md with more accurate build instructions.

Closes #2.